### PR TITLE
Force user to specify protocol to avoid app to crash.

### DIFF
--- a/app/src/main/java/org/piwigo/ui/login/LoginViewModel.java
+++ b/app/src/main/java/org/piwigo/ui/login/LoginViewModel.java
@@ -135,7 +135,7 @@ public class LoginViewModel extends ViewModel {
         if (url.get() == null || url.get().isEmpty()) {
             urlError.set(resources.getString(R.string.login_url_empty));
             return false;
-        } else if (!WEB_URL.matcher(url.get()).matches()) {
+        } else if (!isValidAddress(url.get())) {
             urlError.set(resources.getString(R.string.login_url_invalid));
             return false;
         }
@@ -170,6 +170,8 @@ public class LoginViewModel extends ViewModel {
             }
         });
     }
+
+    private boolean isValidAddress(String string) { return string.startsWith("https://") || string.startsWith("http://"); }
 
     private boolean isEmpty(String string) {
         return string == null || string.isEmpty();

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -44,7 +44,7 @@
     <string name="login_url_hint">Server address</string>
     <string name="login_url_description">URL of the Piwigo gallery to login</string>
     <string name="login_url_empty">Enter your server address</string>
-    <string name="login_url_invalid">Not a valid server address</string>
+    <string name="login_url_invalid">Please try adding "http://" or "https://" before the address.</string>
     <string name="login_username_description">Username to login to the Piwigo gallery</string>
     <string name="login_username_empty">Enter your username</string>
     <string name="login_username_hint">Username (empty for guest)</string>


### PR DESCRIPTION
Should give a nice possible fix to issue #80 

A good way to fix it could also be using a [Spinner](https://developer.android.com/guide/topics/ui/controls/spinner) from native Android UI, 
and forcing user to pick either "HTTP" or "HTTPS" option.