### PR TITLE
Added sample details for login issues

### DIFF
--- a/app/src/main/java/org/piwigo/helper/DialogHelper.java
+++ b/app/src/main/java/org/piwigo/helper/DialogHelper.java
@@ -32,6 +32,17 @@ public class DialogHelper {
         builder.show();
     }
 
+    public void showLogDialog(String title, String message, Context context) {
+        AlertDialog.Builder builder = new AlertDialog.Builder(context, R.style.Theme_Piwigo_ErrorDialog);
+
+        builder.setTitle(title);
+        builder.setMessage(message);
+        builder.setPositiveButton(R.string.button_ok, (dialog, which) -> {
+            closeDialog(dialog);
+        });
+        builder.show();
+    }
+
     private void closeDialog(DialogInterface dialog)
     {
         dialog.cancel();

--- a/app/src/main/java/org/piwigo/ui/login/LoginActivity.java
+++ b/app/src/main/java/org/piwigo/ui/login/LoginActivity.java
@@ -39,6 +39,7 @@ import com.google.android.material.snackbar.Snackbar;
 
 import org.piwigo.R;
 import org.piwigo.databinding.ActivityLoginBinding;
+import org.piwigo.helper.DialogHelper;
 import org.piwigo.io.model.LoginResponse;
 import org.piwigo.ui.shared.BaseActivity;
 
@@ -143,8 +144,12 @@ public class LoginActivity extends BaseActivity {
             Snackbar.make(binding.getRoot(), R.string.login_host_error, Snackbar.LENGTH_LONG)
                     .show();
         else
-            Snackbar.make(binding.getRoot(), R.string.login_error, Snackbar.LENGTH_LONG)
-                    .show();
+            Snackbar.make(binding.getRoot(), R.string.login_error, Snackbar.LENGTH_LONG).setAction(R.string.show_details, new View.OnClickListener() {
+                @Override
+                public void onClick(View v) {
+                    DialogHelper.INSTANCE.showLogDialog(getResources().getString(R.string.login_error), throwable.getMessage(), binding.getRoot().getContext());
+                }
+            }).show();
     }
 
     private void setResultIntent(Account account) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -183,4 +183,5 @@
     <string name="not_admin_explanation">You need to be logged to do this.</string>
 
     <string name="no_internet">Oops! It seems like you have no internet connection. Please connect and try again.</string>
+    <string name="show_details">Show details</string>
 </resources>


### PR DESCRIPTION
Just added a "show details" action to the already existing Snackbar.
It shows a short description of what the issue is.

For example:

```
Login failed = Invalid credentials
```
```
Handshake failed = Invalid SSL cert
 ```
```
Attempt to read from field 'boolean org.piwigo.io.model.SuccessResponse.result' on a null object reference = Not a Piwigo server
```