### PR TITLE
Fix for account selection highlighting

### DIFF
--- a/app/src/main/java/org/piwigo/ui/account/ManageAccountsActivity.java
+++ b/app/src/main/java/org/piwigo/ui/account/ManageAccountsActivity.java
@@ -23,13 +23,11 @@ import android.accounts.Account;
 import android.accounts.AccountManager;
 import android.accounts.OnAccountsUpdateListener;
 import androidx.lifecycle.ViewModelProviders;
-import androidx.lifecycle.Observer;
 import android.content.Intent;
 import androidx.databinding.DataBindingUtil;
 import android.os.Build;
 import android.os.Bundle;
 
-import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 import androidx.core.app.NavUtils;
 import androidx.recyclerview.widget.LinearLayoutManager;
@@ -42,8 +40,6 @@ import org.piwigo.databinding.ActivityManageAccountsBinding;
 import org.piwigo.ui.login.LoginActivity;
 import org.piwigo.ui.shared.BaseActivity;
 import org.piwigo.ui.shared.BindingRecyclerViewAdapter;
-
-import java.util.List;
 
 import javax.inject.Inject;
 
@@ -87,24 +83,26 @@ public class ManageAccountsActivity extends BaseActivity implements OnAccountsUp
         setSupportActionBar(toolbar);
         viewModel.title.set(getString(R.string.title_activity_accounts));
 
-        userManager.getAccounts().observe(this, new Observer<List<Account>>() {
-            @Override
-            public void onChanged(@Nullable List<Account> newItems) {
-                BindingRecyclerViewAdapter<Account> a = (BindingRecyclerViewAdapter<Account>) binding.accountRecycler.getAdapter();
+        userManager.getAccounts().observe(this, newItems -> {
+            BindingRecyclerViewAdapter<Account> a = (BindingRecyclerViewAdapter<Account>) binding.accountRecycler.getAdapter();
 
-                if (a != null) {
-                    a.update(newItems);
-                }
+            if (a != null) {
+                a.update(newItems);
             }
         });
-        userManager.getActiveAccount().observe(this, new Observer<Account>(){
-            @Override
-            public void onChanged(@Nullable Account account) {
-                BindingRecyclerViewAdapter<Account> a = (BindingRecyclerViewAdapter<Account>) binding.accountRecycler.getAdapter();
+        userManager.getActiveAccount().observe(this, account -> {
+            BindingRecyclerViewAdapter<Account> a = (BindingRecyclerViewAdapter<Account>) binding.accountRecycler.getAdapter();
 
-                if (a != null) {
-                    a.notifyDataSetChanged();
-                }
+            if (a != null) {
+                a.notifyDataSetChanged();
+            }
+        });
+
+        viewModel.selectedAccount.observe(this, account -> {
+            BindingRecyclerViewAdapter<Account> a = (BindingRecyclerViewAdapter<Account>) binding.accountRecycler.getAdapter();
+
+            if (a != null) {
+                finish();
             }
         });
 

--- a/app/src/main/java/org/piwigo/ui/account/ManageAccountsViewModel.java
+++ b/app/src/main/java/org/piwigo/ui/account/ManageAccountsViewModel.java
@@ -21,6 +21,7 @@ package org.piwigo.ui.account;
 
 import android.accounts.Account;
 import androidx.lifecycle.LiveData;
+import androidx.lifecycle.MutableLiveData;
 import androidx.lifecycle.ViewModel;
 import android.content.Intent;
 import androidx.databinding.ObservableField;
@@ -38,7 +39,7 @@ public class ManageAccountsViewModel extends ViewModel {
     public final ObservableField<String> title = new ObservableField<>();
 
     public final LiveData<List<Account>> accounts;
-    Account selectedAccount;
+    MutableLiveData<Account> selectedAccount = new MutableLiveData<>();
 
     private List<Account> items;
     public final BindingRecyclerViewAdapter.ViewBinder<Account> viewBinder = new AccountViewBinder();
@@ -49,11 +50,11 @@ public class ManageAccountsViewModel extends ViewModel {
         this.userManager = userManager;
         accounts = userManager.getAccounts();
         items = accounts.getValue();
-        selectedAccount = userManager.getActiveAccount().getValue();
+        selectedAccount.setValue(userManager.getActiveAccount().getValue());
     }
 
     public Account getSelectedAccount(){
-        return selectedAccount;
+        return selectedAccount.getValue();
     }
 
     public List<Account> getItems() {
@@ -76,7 +77,7 @@ public class ManageAccountsViewModel extends ViewModel {
             boolean x = vm.isActive();
             viewHolder.itemView.setSelected(x);
             viewHolder.itemView.setOnClickListener(v -> {
-                selectedAccount = account;
+                selectedAccount.postValue(account);
 
                 userManager.setActiveAccount(account);
             });

--- a/app/src/main/res/layout/account_row.xml
+++ b/app/src/main/res/layout/account_row.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
   ~ Piwigo for Android
   ~ Copyright (C) 2017-2018 Raphael Mack http://www.raphael-mack.de
   ~
@@ -24,29 +23,33 @@
             name="viewModel"
             type="org.piwigo.ui.account.AccountViewModel" />
     </data>
+
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_centerVertical="true"
+        android:layout_marginBottom="1dp"
+        android:background="@android:color/white"
         android:orientation="vertical"
-        android:padding="8dp"
-        android:background="@android:color/white">
+        android:padding="8dp">
 
-        <TextView
-            android:id="@+id/username"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_weight="1"
-            android:textStyle="bold"
-            android:text="@{viewModel.username}"/>
+        <RadioGroup
+            android:id="@+id/radioGroup"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
 
-        <TextView
-            android:id="@+id/gallery_url"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_weight="1"
-            android:scrollHorizontally="true"
-            android:text="@{viewModel.siteUrl}"/>
+            <RadioButton
+                android:id="@+id/radioBtn"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_weight="2"
+                android:paddingLeft="10dp"
+                android:checked="@{viewModel.active}"
+                android:clickable="false"
+                android:maxLines="2"
+                android:scrollHorizontally="true"
+                android:text="@{viewModel.username + `\n` + viewModel.siteUrl}" />
+        </RadioGroup>
     </LinearLayout>
 
 </layout>


### PR DESCRIPTION
As expected, a radio button did replace the "grey" tints background for highlighting.

According to what was discussed with @ramack , yhe user is also sent back to its gallery after selecting an account.

This is a fix for #135 