### PR TITLE
Chunk photos at upload

### DIFF
--- a/app/src/main/java/org/piwigo/accounts/UserManager.java
+++ b/app/src/main/java/org/piwigo/accounts/UserManager.java
@@ -53,6 +53,7 @@ public class UserManager {
     @VisibleForTesting static final String KEY_USERNAME = "username";
     @VisibleForTesting static final String KEY_COOKIE = "cookie";
     @VisibleForTesting static final String KEY_TOKEN  = "token";
+    @VisibleForTesting static final String KEY_CHUNK_SIZE  = "chunk_size";
 
     @VisibleForTesting static final String GUEST_ACCOUNT_NAME = "guest";
 
@@ -159,6 +160,15 @@ public class UserManager {
     // maybe it would be better to just keep it in the UserRepository
     public String getToken(Account account) {
         return accountManager.getUserData(account, KEY_TOKEN);
+    }
+
+    public void setChunkSize(Account account, int chunkSize) {
+        accountManager.setUserData(account, KEY_CHUNK_SIZE, String.valueOf(chunkSize));
+    }
+
+    public int getChunkSize(Account account)
+    {
+        return Integer.parseInt(accountManager.getUserData(account, KEY_CHUNK_SIZE));
     }
 
     public boolean isGuest(Account account) {

--- a/app/src/main/java/org/piwigo/bg/UploadService.java
+++ b/app/src/main/java/org/piwigo/bg/UploadService.java
@@ -132,7 +132,7 @@ public class UploadService extends IntentService {
         //Chunks
         long tmpFileSize = getFileSize(uploadAction.getUploadData().getTargetUri());
         int chunkSize = getChunkSize(); // Chunk max size = 1MB
-        int expectedChunks = tmpFileSize < chunkSize ? 1 : (int) (tmpFileSize / chunkSize) + 1;
+        int expectedChunks = tmpFileSize <= chunkSize ? 1 : (int) (tmpFileSize / chunkSize) + 1;
         //Instances
         MultipartBody.Part fileParts[] = new MultipartBody.Part[expectedChunks];
         UploadPromise promise = new UploadPromise();

--- a/app/src/main/java/org/piwigo/bg/UploadService.java
+++ b/app/src/main/java/org/piwigo/bg/UploadService.java
@@ -213,7 +213,7 @@ public class UploadService extends IntentService {
      * @return an array of x chunks containing chunks of source
      */
     public static byte[][] splitArray(byte[] source, int chunkSize) {
-        byte[][] newArray = new byte[(int) Math.ceil(source.length / (double) chunkSize)][chunkSize];
+        byte[][] newArray = new byte[(source.length / chunkSize) + 1][chunkSize];
         int start = 0;
 
         for (int i = 0; i < newArray.length; i++) {

--- a/app/src/main/java/org/piwigo/bg/UploadService.java
+++ b/app/src/main/java/org/piwigo/bg/UploadService.java
@@ -30,6 +30,8 @@ import android.net.Uri;
 import android.provider.OpenableColumns;
 import android.util.Log;
 
+import androidx.annotation.NonNull;
+
 import com.tingyik90.snackprogressbar.SnackProgressBar;
 import com.tingyik90.snackprogressbar.SnackProgressBarManager;
 
@@ -279,7 +281,7 @@ public class UploadService extends IntentService {
 
         call.enqueue(new Callback<ImageUploadResponse>() {
             @Override
-            public void onResponse(Call<ImageUploadResponse> call, Response<ImageUploadResponse> response) {
+            public void onResponse(@NonNull Call<ImageUploadResponse> call, @NonNull Response<ImageUploadResponse> response) {
                 if (response.raw().code() == 200 && ("ok".equals(response.body().up_stat))) {
                     snackProgressEvent.setSnackbarProgressMax(promise.getTotalChunks());
                     snackProgressEvent.setSnackbarProgress(promise.getCurrentChunk());

--- a/app/src/main/java/org/piwigo/bg/UploadService.java
+++ b/app/src/main/java/org/piwigo/bg/UploadService.java
@@ -178,12 +178,13 @@ public class UploadService extends IntentService {
     public int getChunkSize()
     {
         int networkType = NetworkHelper.INSTANCE.getNetworkType(getApplicationContext());
+        int chunkSize = userManager.getChunkSize(userManager.getActiveAccount().getValue());
 
         if (networkType == ConnectivityManager.TYPE_WIFI) {
-            return (1024 * 1024); // 1MB
+            return chunkSize; // 500KB by default
         }
         else {
-            return (256 * 1024); // 256KB
+            return (chunkSize / 2); // 250KB by default
         }
     }
 

--- a/app/src/main/java/org/piwigo/bg/UploadService.java
+++ b/app/src/main/java/org/piwigo/bg/UploadService.java
@@ -24,9 +24,11 @@ import android.app.IntentService;
 import android.app.Service;
 import android.content.Context;
 import android.content.Intent;
+import android.database.Cursor;
+import android.net.ConnectivityManager;
+import android.net.Uri;
+import android.provider.OpenableColumns;
 import android.util.Log;
-
-import androidx.annotation.NonNull;
 
 import com.tingyik90.snackprogressbar.SnackProgressBar;
 import com.tingyik90.snackprogressbar.SnackProgressBarManager;
@@ -35,6 +37,7 @@ import org.greenrobot.eventbus.EventBus;
 import org.piwigo.R;
 import org.piwigo.accounts.UserManager;
 import org.piwigo.bg.action.UploadAction;
+import org.piwigo.helper.NetworkHelper;
 import org.piwigo.helper.NotificationHelper;
 import org.piwigo.io.RestService;
 import org.piwigo.io.RestServiceFactory;
@@ -48,6 +51,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Random;
 
 import javax.inject.Inject;
@@ -104,9 +108,8 @@ public class UploadService extends IntentService {
      *               for details.
      */
     @Override
-    protected void onHandleIntent(Intent intent)
-    {
-        ImageUploadQueue<UploadAction> imageUploadQueue = (ImageUploadQueue<UploadAction>)intent.getSerializableExtra(KEY_UPLOAD_QUEUE);
+    protected void onHandleIntent(Intent intent) {
+        ImageUploadQueue<UploadAction> imageUploadQueue = (ImageUploadQueue<UploadAction>) intent.getSerializableExtra(KEY_UPLOAD_QUEUE);
         if (imageUploadQueue == null)
             return;
         totalImagesCount = imageUploadQueue.size();
@@ -118,16 +121,21 @@ public class UploadService extends IntentService {
         snackProgressEvent.setSnackbarDuration(SnackProgressBarManager.LENGTH_INDEFINITE);
         snackProgressEvent.setAction(SnackProgressEvent.SnackbarUpdateAction.REFRESH);
         snackProgressEvent.setSnackbarDesc(getResources().getString(R.string.upload_started));
-        onUploadStarted(imageUploadQueue);
+        onChunkedUploadStarted(imageUploadQueue);
     }
 
-    protected void onUploadStarted(ImageUploadQueue<UploadAction> imageUploadQueue)
-    {
+    protected void onChunkedUploadStarted(ImageUploadQueue<UploadAction> imageUploadQueue) {
         final UploadAction uploadAction;
         if ((uploadAction = imageUploadQueue.poll()) == null)
             return;
+
+        //Chunks
+        long tmpFileSize = getFileSize(uploadAction.getUploadData().getTargetUri());
+        int chunkSize = getChunkSize(); // Chunk max size = 1MB
+        int expectedChunks = tmpFileSize < chunkSize ? 1 : (int) (tmpFileSize / chunkSize) + 1;
         //Instances
-        MultipartBody.Part filePart;
+        MultipartBody.Part fileParts[] = new MultipartBody.Part[expectedChunks];
+        UploadPromise promise = new UploadPromise();
         RestService restService;
         //Local variables
         ArrayList<RequestBody> requestBodies;
@@ -143,12 +151,74 @@ public class UploadService extends IntentService {
             Log.e("UploadService", "IOException", e.getCause());
             content = new byte[0];
         }
-        filePart = MultipartBody.Part.createFormData("file", uploadAction.getFileName(), RequestBody.create(MediaType.parse("image/*"), content));
+
+        byte[][] splittedContent = splitArray(content, chunkSize);
+        for (int i = 0; i < splittedContent.length; i++) {
+            fileParts[i] = MultipartBody.Part.createFormData("file", uploadAction.getFileName(), RequestBody.create(MediaType.parse("image/*"), splittedContent[i]));
+        }
         restService = restServiceFactory.createForAccount(userManager.getActiveAccount().getValue());
         requestBodies = createUploadRequest(uploadAction.getFileName(), getPhotoName(uploadAction.getFileName()), userManager.getActiveAccount().getValue());
 
+        //Promise building
+        promise.setFileParts(fileParts);
+        promise.setRequestBodies(requestBodies);
+        promise.setCatId(uploadAction.getUploadData().getCategoryId());
+        promise.setCurrentChunk(0);
+        promise.setTotalChunks(expectedChunks);
         if (uploadAction.getUploadData().getCategoryId() > 0)
-            callUploadResponse(imageUploadQueue, restService, requestBodies, uploadAction.getUploadData().getCategoryId(), filePart);
+            callChunkedUploadResponse(imageUploadQueue, restService, promise);
+    }
+
+    /**
+     * Pick a chunk size depending of the network mode (if on wifi, 1MB, 256KB for mobile data)
+     * @return chunkSize (1MB, 256KB for mobile data or anything else)
+     */
+    public int getChunkSize()
+    {
+        int networkType = NetworkHelper.INSTANCE.getNetworkType(getApplicationContext());
+
+        if (networkType == ConnectivityManager.TYPE_WIFI) {
+            return (1024 * 1024); // 1MB
+        }
+        else {
+            return (256 * 1024); // 256KB
+        }
+    }
+
+    /**
+     * Get the file size from the given file URI (getting as a File does not work because of Android's way to manage temp content)
+     *
+     * @param fileUri (file path on the device)
+     * @return fileSize (as long)
+     */
+    public long getFileSize(Uri fileUri) {
+        Cursor cursor = getContentResolver().query(fileUri, null, null, null, null);
+        long size = 0;
+
+        if (cursor != null) {
+            cursor.moveToFirst();
+            size = cursor.getLong(cursor.getColumnIndex(OpenableColumns.SIZE));
+            cursor.close();
+        }
+        return size;
+    }
+
+    /**
+     * Split the file in parts to send multiple Multipart.Parts
+     *
+     * @param source    byte array containing the whole image
+     * @param chunkSize size of the chunks (1024 * 1024 = 1MB for instance)
+     * @return an array of x chunks containing chunks of source
+     */
+    public static byte[][] splitArray(byte[] source, int chunkSize) {
+        byte[][] newArray = new byte[(int) Math.ceil(source.length / (double) chunkSize)][chunkSize];
+        int start = 0;
+
+        for (int i = 0; i < newArray.length; i++) {
+            newArray[i] = Arrays.copyOfRange(source, start, start + chunkSize);
+            start += chunkSize;
+        }
+        return newArray;
     }
 
     /**
@@ -169,6 +239,7 @@ public class UploadService extends IntentService {
             photoName = imageName;
         return (photoName);
     }
+
     /**
      * Create the request bodies for the upload form
      *
@@ -187,33 +258,49 @@ public class UploadService extends IntentService {
         return (requestBodies);
     }
 
-    private void callUploadResponse(ImageUploadQueue<UploadAction> imageUploadQueue, RestService restService, ArrayList<RequestBody> requestBodies,
-                                    int catId, MultipartBody.Part filePart) {
-        Call<ImageUploadResponse> call = restService.uploadImage(requestBodies.get(0), catId, requestBodies.get(1), requestBodies.get(2), filePart);
-        RefreshRequestEvent refreshEvent = new RefreshRequestEvent(catId);
+    private void callChunkedUploadResponse(ImageUploadQueue<UploadAction> imageUploadQueue, RestService restService, UploadPromise promise) {
+
+        RefreshRequestEvent refreshEvent = new RefreshRequestEvent(promise.getCatId());
+
+        //We have uploaded every chunk, let's jump to the next image
+        if (promise.getCurrentChunk() > promise.getTotalChunks() - 1) {
+            uploadedImages++;
+            onChunkedUploadStarted(imageUploadQueue);
+            return;
+        }
+        Call<ImageUploadResponse> call = restService.uploadChunkedImage(
+                promise.getRequestBodies().get(0),
+                promise.getCatId(),
+                promise.getRequestBodies().get(1),
+                promise.getRequestBodies().get(2),
+                promise.getCurrentChunk(),
+                promise.getTotalChunks(),
+                promise.getFileParts()[promise.getCurrentChunk()]);
 
         call.enqueue(new Callback<ImageUploadResponse>() {
             @Override
-            public void onResponse(@NonNull Call<ImageUploadResponse> call, @NonNull Response<ImageUploadResponse> response) {
+            public void onResponse(Call<ImageUploadResponse> call, Response<ImageUploadResponse> response) {
                 if (response.raw().code() == 200 && ("ok".equals(response.body().up_stat))) {
+                    snackProgressEvent.setSnackbarProgressMax(promise.getTotalChunks());
+                    snackProgressEvent.setSnackbarProgress(promise.getCurrentChunk());
                     snackProgressEvent.setSnackbarDesc(String.format(getResources().getString(R.string.upload_progress_body), uploadedImages, totalImagesCount));
                     EventBus.getDefault().post(snackProgressEvent);
-                    uploadedImages++;
-                    if (imageUploadQueue.size() <= 0) {
+                    promise.setCurrentChunk(promise.getCurrentChunk() + 1);
+                    if (imageUploadQueue.size() <= 0 && promise.getCurrentChunk() == promise.getTotalChunks()) {
                         NotificationHelper.INSTANCE.sendNotification(getResources().getString(R.string.upload_success), String.format(getResources().getString(R.string.upload_success_body), totalImagesCount, response.body().up_result.up_category.catlabel), getApplicationContext());
                         snackProgressEvent.setSnackbarDesc(String.format(getResources().getString(R.string.upload_success_body), totalImagesCount, response.body().up_result.up_category.catlabel));
                         snackProgressEvent.setAction(SnackProgressEvent.SnackbarUpdateAction.KILL);
                         EventBus.getDefault().post(snackProgressEvent);
                         EventBus.getDefault().post(refreshEvent);
                     }
-                    onUploadStarted(imageUploadQueue);
+                    callChunkedUploadResponse(imageUploadQueue, restService, promise);
                 } else {
                     String add = " (code: " + response.raw().code() + ")";
                     // TODO: handle this properly for #161
                     if (response.body() != null) {
-                        if(response.body().err != null) {
+                        if (response.body().err != null) {
                             add = " (" + response.body().err.message + ")";
-                        }else{
+                        } else {
                             add = " (unknown)"; // this should be quite abnormal to happen but who knows...
                         }
                     }
@@ -226,7 +313,7 @@ public class UploadService extends IntentService {
             }
 
             @Override
-            public void onFailure(@NonNull Call<ImageUploadResponse> call, @NonNull Throwable t) {
+            public void onFailure(Call<ImageUploadResponse> call, Throwable t) {
                 // TODO: handle this properly for #161
                 NotificationHelper.INSTANCE.sendNotification(getResources().getString(R.string.upload_failed), getResources().getString(R.string.upload_error), getApplicationContext());
                 snackProgressEvent.setSnackbarDesc(getResources().getString(R.string.upload_failed));
@@ -248,6 +335,52 @@ public class UploadService extends IntentService {
             byteBuffer.write(buffer, 0, len);
         }
         return byteBuffer.toByteArray();
+    }
+
+    public class UploadPromise {
+        MultipartBody.Part[] fileParts;
+        ArrayList<RequestBody> requestBodies;
+        int catId, currentChunk, totalChunks;
+
+        public void setFileParts(MultipartBody.Part[] fileParts) {
+            this.fileParts = fileParts;
+        }
+
+        public void setRequestBodies(ArrayList<RequestBody> requestBodies) {
+            this.requestBodies = requestBodies;
+        }
+
+        public void setCatId(int catId) {
+            this.catId = catId;
+        }
+
+        public void setCurrentChunk(int currentChunk) {
+            this.currentChunk = currentChunk;
+        }
+
+        public void setTotalChunks(int totalChunks) {
+            this.totalChunks = totalChunks;
+        }
+
+        public MultipartBody.Part[] getFileParts() {
+            return fileParts;
+        }
+
+        public ArrayList<RequestBody> getRequestBodies() {
+            return requestBodies;
+        }
+
+        public int getCatId() {
+            return catId;
+        }
+
+        public int getCurrentChunk() {
+            return currentChunk;
+        }
+
+        public int getTotalChunks() {
+            return totalChunks;
+        }
     }
 
 }

--- a/app/src/main/java/org/piwigo/helper/NetworkHelper.java
+++ b/app/src/main/java/org/piwigo/helper/NetworkHelper.java
@@ -12,13 +12,30 @@ public class NetworkHelper {
         INSTANCE = this;
     }
 
-    public boolean hasInternet(Context context) {
+    public NetworkInfo getCurrentNetwork(Context context)
+    {
         ConnectivityManager cm = (ConnectivityManager) context.getSystemService(Context.CONNECTIVITY_SERVICE);
-        NetworkInfo currentNetwork = cm.getActiveNetworkInfo();
+        NetworkInfo network = cm.getActiveNetworkInfo();
+
+        return (network);
+    }
+
+    public boolean hasInternet(Context context) {
+        NetworkInfo currentNetwork = getCurrentNetwork(context);
 
         if (currentNetwork != null) {
             return (currentNetwork.isConnected());
         }
         return (false);
+    }
+
+    public int getNetworkType(Context context)
+    {
+        NetworkInfo currentNetwork = getCurrentNetwork(context);
+
+        if (currentNetwork != null) {
+            return (currentNetwork.getType());
+        }
+        return (0);
     }
 }

--- a/app/src/main/java/org/piwigo/helper/NetworkHelper.java
+++ b/app/src/main/java/org/piwigo/helper/NetworkHelper.java
@@ -15,6 +15,9 @@ public class NetworkHelper {
     public NetworkInfo getCurrentNetwork(Context context)
     {
         ConnectivityManager cm = (ConnectivityManager) context.getSystemService(Context.CONNECTIVITY_SERVICE);
+        //The usage of getActiveNetworkInfo() is deprecated since API 28
+        //The proper way would be to use getActiveNetwork, but it is only supported since API 23
+        //So for now we may want to keep it like this
         NetworkInfo network = cm.getActiveNetworkInfo();
 
         return (network);
@@ -36,6 +39,6 @@ public class NetworkHelper {
         if (currentNetwork != null) {
             return (currentNetwork.getType());
         }
-        return (0);
+        return (-1); //The symbolic name for "0" is MOBILE, if we end this return it means that there is no internet connection so it should be -1
     }
 }

--- a/app/src/main/java/org/piwigo/io/RestService.java
+++ b/app/src/main/java/org/piwigo/io/RestService.java
@@ -84,4 +84,16 @@ public interface RestService {
             @Part MultipartBody.Part filePart
     );
 
+    @Multipart
+    @POST("ws.php?method=pwg.images.upload")
+    Call<ImageUploadResponse> uploadChunkedImage(
+            @Part("image") RequestBody image,
+            @Part("category") Integer category,
+            @Part("name") RequestBody name,
+            @Part("pwg_token") RequestBody token,
+            @Part("chunk") Integer chunk, //The current chunk (starts at 0)
+            @Part("chunks") Integer chunks, //Number of chunks
+            @Part MultipartBody.Part filePart
+    );
+
 }

--- a/app/src/main/java/org/piwigo/io/event/SnackProgressEvent.java
+++ b/app/src/main/java/org/piwigo/io/event/SnackProgressEvent.java
@@ -6,6 +6,8 @@ public class SnackProgressEvent extends SimpleEvent
     private String snackbarDesc;
     private int snackbarId;
     private int snackbarDuration;
+    private int snackbarProgressMax;
+    private int snackbarProgress;
     private SnackbarUpdateAction action;
 
     public SnackProgressEvent()
@@ -30,6 +32,16 @@ public class SnackProgressEvent extends SimpleEvent
         this.snackbarDuration = duration;
     }
 
+    public void setSnackbarProgressMax(int snackbarProgressMax)
+    {
+        this.snackbarProgressMax = snackbarProgressMax;
+    }
+
+    public void setSnackbarProgress(int snackbarProgress)
+    {
+        this.snackbarProgress = snackbarProgress;
+    }
+
     public void setAction(SnackbarUpdateAction action) {
         this.action = action;
     }
@@ -49,6 +61,16 @@ public class SnackProgressEvent extends SimpleEvent
     public int getSnackbarDuration()
     {
         return (snackbarDuration);
+    }
+
+    public int getSnackbarProgressMax()
+    {
+        return (snackbarProgressMax);
+    }
+
+    public int getSnackbarProgress()
+    {
+        return (snackbarProgress);
     }
 
     public SnackbarUpdateAction getAction() {

--- a/app/src/main/java/org/piwigo/io/model/StatusResponse.java
+++ b/app/src/main/java/org/piwigo/io/model/StatusResponse.java
@@ -48,6 +48,8 @@ public class StatusResponse {
 
         @SerializedName("upload_file_types") public String uploadFileTypes;
 // TODO: add "available_sizes":["square","thumb","small","medium","large","xxlarge"]
+
+        @SerializedName("upload_form_chunk_size") public Integer uploadFormChunkSize;
     }
 
 }

--- a/app/src/main/java/org/piwigo/ui/launcher/LauncherActivity.java
+++ b/app/src/main/java/org/piwigo/ui/launcher/LauncherActivity.java
@@ -72,6 +72,7 @@ public class LauncherActivity extends BaseActivity {
                             Log.i(TAG, "Login succeeded: " + loginResponse.pwgId);
                             userManager.setCookie(a, loginResponse.pwgId);
                             userManager.setToken(a, loginResponse.statusResponse.result.pwgToken);
+                            userManager.setChunkSize(a, loginResponse.statusResponse.result.uploadFormChunkSize);
                         }
                     });
 

--- a/app/src/main/java/org/piwigo/ui/main/MainActivity.java
+++ b/app/src/main/java/org/piwigo/ui/main/MainActivity.java
@@ -296,6 +296,7 @@ public class MainActivity extends BaseActivity implements HasAndroidInjector {
 
             if (bar != null) {
                 bar.setMessage(progressEvent.getSnackbarDesc());
+                snackProgressBarManager.setProgress(progressEvent.getSnackbarProgress());
                 if (progressEvent.getAction() == (SnackProgressEvent.SnackbarUpdateAction.KILL)) {
                     bar.setType(SnackProgressBar.TYPE_NORMAL);
                     bar.setAction(getResources().getString(R.string.button_ok), () -> snackProgressBarManager.dismiss());
@@ -306,7 +307,8 @@ public class MainActivity extends BaseActivity implements HasAndroidInjector {
                 if (progressEvent.getAction().equals(SnackProgressEvent.SnackbarUpdateAction.KILL)) {
                     return;
                 }
-                bar = new SnackProgressBar(progressEvent.getSnackbarType(), progressEvent.getSnackbarDesc()).setIsIndeterminate(true);
+                bar = new SnackProgressBar(progressEvent.getSnackbarType(), progressEvent.getSnackbarDesc()).setIsIndeterminate(false);
+                bar.setProgressMax(progressEvent.getSnackbarProgressMax());
                 snackProgressBarManager.put(bar, progressEvent.getSnackbarId());
                 snackProgressBarManager.show(bar, progressEvent.getSnackbarDuration());
             }

--- a/app/src/main/java/org/piwigo/ui/main/MainActivity.java
+++ b/app/src/main/java/org/piwigo/ui/main/MainActivity.java
@@ -191,6 +191,7 @@ public class MainActivity extends BaseActivity implements HasAndroidInjector {
                         // TODO: it is crazy to have this code here AND in LauncherActivity
                         userManager.setCookie(account, loginResponse.pwgId);
                         userManager.setToken(account, loginResponse.statusResponse.result.pwgToken);
+                        userManager.setChunkSize(account, loginResponse.statusResponse.result.uploadFormChunkSize);
                     }
                 });
                 initStartFragment(viewModel);

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -175,7 +175,7 @@
     <string name="upload_success">Upload successful</string>
     <string name="upload_failed">Upload failed</string>
     <string name="upload_error">An error occurred while upload your photo(s). Please try again.</string>
-    <string name="upload_progress_body">Uploaded %1$d / %2$d photos</string>
+    <string name="upload_progress_body">Uploading %1$d / %2$d photos</string>
     <string name="upload_started">Uploading your photos</string>
     <string name="upload_success_body">Uploaded %1$d photo(s) to %2$s</string>
     <string name="storage_permission_title">Missing permissions.</string>


### PR DESCRIPTION
This is a solution for #126 

The size of the chunks is choose by the network mode (either wifi or mobile), assuming the mobile network will by slower than the wifi network.

Tested: it works on a single image upload or for 10+ images at once. 