### PR TITLE
Fix back button on main view

### DIFF
--- a/app/src/main/java/org/piwigo/ui/main/MainActivity.java
+++ b/app/src/main/java/org/piwigo/ui/main/MainActivity.java
@@ -225,7 +225,7 @@ public class MainActivity extends BaseActivity implements HasAndroidInjector {
 
     @Override
     public void onBackPressed() {
-        if (mDrawerToggle.isDrawerIndicatorEnabled()) {
+        if (getCurrentCategoryId() != 0 && mDrawerToggle.isDrawerIndicatorEnabled()) {
             MainViewModel viewModel = ViewModelProviders.of(this, viewModelFactory).get(MainViewModel.class);
             viewModel.drawerState.set(false);
         } else {


### PR DESCRIPTION
It shouldn't ignore back button if in root view of the gallery. Android
apps are supposed to close down if back is pressed on first activity