### PR TITLE
Fix the drawer to close the drawer on all options

### DIFF
--- a/app/src/main/java/org/piwigo/ui/main/MainActivity.java
+++ b/app/src/main/java/org/piwigo/ui/main/MainActivity.java
@@ -36,6 +36,7 @@ import android.view.MenuItem;
 import android.view.View;
 import android.widget.Toast;
 
+import com.google.android.material.navigation.NavigationView;
 import com.google.android.material.snackbar.Snackbar;
 import com.leinardi.android.speeddial.SpeedDialActionItem;
 import com.leinardi.android.speeddial.SpeedDialView;
@@ -89,6 +90,7 @@ import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
 import androidx.lifecycle.Observer;
 import androidx.lifecycle.ViewModelProviders;
+
 import dagger.android.AndroidInjection;
 import dagger.android.AndroidInjector;
 import dagger.android.DispatchingAndroidInjector;
@@ -141,8 +143,6 @@ public class MainActivity extends BaseActivity implements HasAndroidInjector {
         DrawerHeaderBinding headerBinding = DataBindingUtil.inflate(getLayoutInflater(), R.layout.drawer_header, mBinding.navigationView, false);
 
         viewModel = ViewModelProviders.of(this, viewModelFactory).get(MainViewModel.class);
-        viewModel.getSelectedNavigationItemId().observe(this, this::itemSelected);
-
         mBinding.setViewModel(viewModel);
         headerBinding.setViewModel(viewModel);
         mBinding.navigationView.addHeaderView(headerBinding.getRoot());
@@ -155,7 +155,6 @@ public class MainActivity extends BaseActivity implements HasAndroidInjector {
                 R.string.nav_drawer_close
         );
         mBinding.drawerLayout.addDrawerListener(mDrawerToggle);
-
         mDrawerToggle.setDrawerIndicatorEnabled(viewModel.showingRootAlbum.get());
 
         mDrawerCallBack = new Observable.OnPropertyChangedCallback() {
@@ -224,6 +223,14 @@ public class MainActivity extends BaseActivity implements HasAndroidInjector {
         if (savedInstanceState == null) {
             initStartFragment(viewModel);
         }
+
+        NavigationView nav = findViewById(R.id.navigation_view);
+        nav.getMenu().getItem(0).setChecked(true);
+        nav.setNavigationItemSelectedListener(menuItem -> {
+            viewModel.drawerState.set(false);
+            itemSelected(menuItem.getItemId());
+            return true;
+        });
     }
 
     private void initStartFragment(MainViewModel viewModel) {
@@ -284,7 +291,6 @@ public class MainActivity extends BaseActivity implements HasAndroidInjector {
     protected void onResume() {
         super.onResume();
         MainViewModel viewModel = ViewModelProviders.of(this, viewModelFactory).get(MainViewModel.class);
-        viewModel.navigationItemId.set(R.id.nav_albums);
         speedDialView.setVisibility(viewModel.displayFab.get() ? View.VISIBLE : View.INVISIBLE);
         EventBus.getDefault().register(this);
     }
@@ -365,6 +371,7 @@ public class MainActivity extends BaseActivity implements HasAndroidInjector {
                 break;
         }
     }
+
 
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {

--- a/app/src/main/java/org/piwigo/ui/main/MainViewModel.java
+++ b/app/src/main/java/org/piwigo/ui/main/MainViewModel.java
@@ -53,13 +53,11 @@ public class MainViewModel extends ViewModel {
     public ObservableBoolean drawerState = new ObservableBoolean(false);
     public ObservableBoolean showingRootAlbum = new ObservableBoolean(true);
     public ObservableBoolean displayFab = new ObservableBoolean(false);
-    public ObservableInt navigationItemId = new ObservableInt(R.id.nav_albums);
 
     // TODO: finish loginstatus
     public ObservableInt loginStatus = new ObservableInt(STAT_OFFLINE);
     public ObservableField<String> piwigoVersion = new ObservableField<>("");
 
-    private MutableLiveData<Integer> selectedNavigationItemId = new MutableLiveData<>();
     private UserRepository mUserRepository;
     private UserManager userManager;
 
@@ -72,19 +70,6 @@ public class MainViewModel extends ViewModel {
             displayFab.set(!userManager.isGuest(account));
         }
         mUserRepository = userRepository;
-
-        navigationItemId.addOnPropertyChangedCallback(new Observable.OnPropertyChangedCallback() {
-
-            @Override
-            public void onPropertyChanged(Observable sender, int propertyId) {
-                selectedNavigationItemId.setValue(navigationItemId.get());
-                drawerState.set(false);
-            }
-        });
-    }
-
-    LiveData<Integer> getSelectedNavigationItemId() {
-        return selectedNavigationItemId;
     }
 
     private <T> rx.Observable.Transformer<T, T> applySchedulers() {

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -62,8 +62,7 @@
                 android:layout_height="match_parent"
                 android:layout_gravity="start"
                 android:fitsSystemWindows="true"
-                app:menu="@menu/drawer_main"
-                app:selectedItemId="@={viewModel.navigationItemId}" />
+                app:menu="@menu/drawer_main" />
         </androidx.drawerlayout.widget.DrawerLayout>
 
         <com.leinardi.android.speeddial.SpeedDialView

--- a/app/src/main/res/menu/drawer_main.xml
+++ b/app/src/main/res/menu/drawer_main.xml
@@ -1,9 +1,10 @@
 <menu xmlns:android="http://schemas.android.com/apk/res/android">
     <group
         android:id="@+id/nav_group_features"
-        android:checkableBehavior="single">
+        android:checkableBehavior="none">
         <item
             android:id="@+id/nav_albums"
+            android:checkable="false"
             android:icon="@drawable/ic_action_folder"
             android:title="@string/nav_albums" />
     </group>
@@ -13,26 +14,26 @@
         android:visible="true">
         <item
             android:id="@+id/nav_manage_accounts"
-            android:checkable="true"
+            android:checkable="false"
             android:icon="@drawable/ic_action_account_manage"
-            android:title="@string/nav_manage_accounts"/>
+            android:title="@string/nav_manage_accounts" />
     </group>
     <group
         android:id="@+id/nav_group_settings"
         android:checkableBehavior="single">
-       <item
+        <item
             android:id="@+id/nav_settings"
-            android:checkable="true"
+            android:checkable="false"
             android:icon="@drawable/ic_action_settings"
             android:title="@string/nav_settings" />
         <item
             android:id="@+id/nav_about"
-            android:checkable="true"
+            android:checkable="false"
             android:icon="@drawable/ic_action_help"
             android:title="@string/nav_about" />
         <item
             android:id="@+id/nav_privacy"
-            android:checkable="true"
+            android:checkable="false"
             android:icon="@drawable/ic_action_privacy"
             android:title="@string/nav_privacy" />
     </group>

--- a/app/src/test/java/org/piwigo/ui/main/MainViewModelTest.java
+++ b/app/src/test/java/org/piwigo/ui/main/MainViewModelTest.java
@@ -58,13 +58,4 @@ public class MainViewModelTest {
         viewModel = new MainViewModel(userManager, userRepository);
     }
 
-    @Test @SuppressWarnings("unchecked") public void getSelectedMenuItem_observerReceivesSelectedMenuItem() {
-        int itemId = 1;
-        Observer<Integer> observer = (Observer<Integer>) mock(Observer.class);
-        viewModel.getSelectedNavigationItemId().observeForever(observer);
-
-        viewModel.navigationItemId.set(itemId);
-
-        verify(observer).onChanged(itemId);
-    }
 }


### PR DESCRIPTION
In making the items in the drawer menu selectable we stop getting
navigations for items that don't change. but users don't 'select'
"Manage Accounts", they start an activity - so having that menu
item checked afterwards is rather confusing