### PR TITLE
Do not refresh accounts if they didn't change

### DIFF
--- a/app/src/main/java/org/piwigo/accounts/UserManager.java
+++ b/app/src/main/java/org/piwigo/accounts/UserManager.java
@@ -106,7 +106,13 @@ public class UserManager {
      * of a change in the accounts */
     public void refreshAccounts() {
         Account[] accounts = accountManager.getAccountsByType(resources.getString(R.string.account_type));
-        mAllAccounts.setValue(ImmutableList.copyOf(accounts));
+        ImmutableList<Account>  newAccounts = ImmutableList.copyOf(accounts);
+
+        if (newAccounts.equals(mAllAccounts.getValue())) {
+              Log.d(TAG, "no change in accounts");
+              return;
+        }
+        mAllAccounts.setValue(newAccounts);
 
         Account a = mCurrentAccount.getValue();
         setActiveAccount(a == null ? "" : a.name);

--- a/app/src/main/java/org/piwigo/ui/account/ManageAccountsActivity.java
+++ b/app/src/main/java/org/piwigo/ui/account/ManageAccountsActivity.java
@@ -136,6 +136,7 @@ public class ManageAccountsActivity extends BaseActivity {
     }
 
     void removedAccount() {
+        viewModel.items.clear();
         userManager.refreshAccounts();
         List<Account> currentAccounts = userManager.getAccounts().getValue();
         Log.d(TAG, currentAccounts.toString());
@@ -143,7 +144,6 @@ public class ManageAccountsActivity extends BaseActivity {
             startActivity(new Intent(getApplicationContext(), LoginActivity.class));
             finish();
          } else {
-            viewModel.items.clear();
             viewModel.items.addAll(currentAccounts);
          }
     }


### PR DESCRIPTION
This avoids sudden callbacks for no changes - making the tests more reproducible. https://github.com/Piwigo/Piwigo-Android/issues/243 is still happening in tests - and also in reality, but not reproducible