### PR TITLE
#219 Allow user certificates

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -25,6 +25,7 @@
         android:maxSdkVersion="22" />
 
     <application
+        android:networkSecurityConfig="@xml/network_security_config"
         android:name=".PiwigoApplication"
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <base-config>
+        <trust-anchors>
+            <certificates src="system"/>
+            <certificates src="user"/>
+        </trust-anchors>
+    </base-config>
+</network-security-config>


### PR DESCRIPTION
I'm in the same situation as described in #219: NAS with certificates created in a private CA.
I just created a version supporting this situation. 

All I needed to do is to add the xml resource "network_security_config.xml" and to reference it in in the android manifest. The security config in that file accepts the system CA certificates and additional CA certificates installed by the android user via the android settings app.

It would be great if you could include that. Thanks.