### PR TITLE
Move allow clear text to network security config

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -31,7 +31,6 @@
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:supportsRtl="true"
-        android:usesCleartextTraffic="true"
         android:theme="@style/Theme.Piwigo"
         android:largeHeap="true"
         android:fullBackupContent="false">

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <network-security-config>
-    <base-config>
+    <base-config cleartextTrafficPermitted="true" >
         <trust-anchors>
             <certificates src="system"/>
             <certificates src="user"/>


### PR DESCRIPTION
This PR enables android-piwigo to communicate with unsecure piwigo gallery on Android API level 28 and higher. 

According to https://developer.android.com/guide/topics/manifest/application-element#usesCleartextTraffic the ```android:usesCleartextTraffic="true"``` flag is ignored if an Android Network Security Config is present, which it is. This applies for API level 24 and higher. 
For API level 27 and lower the default value is "true", so the flag is not needed in the Manifest.