### PR TITLE
Ok3httpdownloader

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="GradleMigrationSettings" migrationVersion="1" />
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
-        <compositeConfiguration>
-          <compositeBuild compositeDefinitionSource="SCRIPT" />
-        </compositeConfiguration>
+        <option name="testRunner" value="PLATFORM" />
         <option name="distributionType" value="DEFAULT_WRAPPED" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
         <option name="modules">
@@ -15,6 +14,7 @@
           </set>
         </option>
         <option name="resolveModulePerSourceSet" value="false" />
+        <option name="useQualifiedModuleNames" value="true" />
       </GradleProjectSettings>
     </option>
   </component>

--- a/.idea/jarRepositories.xml
+++ b/.idea/jarRepositories.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="RemoteRepositoriesConfiguration">
+    <remote-repository>
+      <option name="id" value="central" />
+      <option name="name" value="Maven Central repository" />
+      <option name="url" value="https://repo1.maven.org/maven2" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="jboss.community" />
+      <option name="name" value="JBoss Community repository" />
+      <option name="url" value="https://repository.jboss.org/nexus/content/repositories/public/" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="MavenRepo" />
+      <option name="name" value="MavenRepo" />
+      <option name="url" value="https://repo.maven.apache.org/maven2/" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="BintrayJCenter" />
+      <option name="name" value="BintrayJCenter" />
+      <option name="url" value="https://jcenter.bintray.com/" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="maven" />
+      <option name="name" value="maven" />
+      <option name="url" value="https://maven.google.com" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="Google" />
+      <option name="name" value="Google" />
+      <option name="url" value="https://dl.google.com/dl/android/maven2/" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="maven2" />
+      <option name="name" value="maven2" />
+      <option name="url" value="https://jitpack.io" />
+    </remote-repository>
+  </component>
+</project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -5,7 +5,7 @@
     <option name="myDefaultNotNull" value="android.support.annotation.NonNull" />
     <option name="myNullables">
       <value>
-        <list size="12">
+        <list size="15">
           <item index="0" class="java.lang.String" itemvalue="org.jetbrains.annotations.Nullable" />
           <item index="1" class="java.lang.String" itemvalue="javax.annotation.Nullable" />
           <item index="2" class="java.lang.String" itemvalue="edu.umd.cs.findbugs.annotations.Nullable" />
@@ -18,12 +18,15 @@
           <item index="9" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.compatqual.NullableDecl" />
           <item index="10" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.compatqual.NullableType" />
           <item index="11" class="java.lang.String" itemvalue="com.android.annotations.Nullable" />
+          <item index="12" class="java.lang.String" itemvalue="org.eclipse.jdt.annotation.Nullable" />
+          <item index="13" class="java.lang.String" itemvalue="io.reactivex.annotations.Nullable" />
+          <item index="14" class="java.lang.String" itemvalue="io.reactivex.rxjava3.annotations.Nullable" />
         </list>
       </value>
     </option>
     <option name="myNotNulls">
       <value>
-        <list size="11">
+        <list size="14">
           <item index="0" class="java.lang.String" itemvalue="org.jetbrains.annotations.NotNull" />
           <item index="1" class="java.lang.String" itemvalue="javax.annotation.Nonnull" />
           <item index="2" class="java.lang.String" itemvalue="edu.umd.cs.findbugs.annotations.NonNull" />
@@ -35,9 +38,12 @@
           <item index="8" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.compatqual.NonNullDecl" />
           <item index="9" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.compatqual.NonNullType" />
           <item index="10" class="java.lang.String" itemvalue="com.android.annotations.NonNull" />
+          <item index="11" class="java.lang.String" itemvalue="org.eclipse.jdt.annotation.NonNull" />
+          <item index="12" class="java.lang.String" itemvalue="io.reactivex.annotations.NonNull" />
+          <item index="13" class="java.lang.String" itemvalue="io.reactivex.rxjava3.annotations.NonNull" />
         </list>
       </value>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" project-jdk-name="JDK" project-jdk-type="JavaSDK" />
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="true" project-jdk-name="1.8" project-jdk-type="JavaSDK" />
 </project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -2,8 +2,8 @@
 <project version="4">
   <component name="ProjectModuleManager">
     <modules>
-      <module fileurl="file://$PROJECT_DIR$/Piwigo-Android.iml" filepath="$PROJECT_DIR$/Piwigo-Android.iml" />
-      <module fileurl="file://$PROJECT_DIR$/app/app.iml" filepath="$PROJECT_DIR$/app/app.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/app/Piwigo-Android.app.iml" filepath="$PROJECT_DIR$/.idea/modules/app/Piwigo-Android.app.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/StudioProjects.Piwigo-Android.iml" filepath="$PROJECT_DIR$/.idea/modules/StudioProjects.Piwigo-Android.iml" />
     </modules>
   </component>
 </project>

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -44,6 +44,10 @@ if (project.file('../PiwigoSigning.properties').exists()) {
 }
 
 android {
+    signingConfigs {
+        release {
+        }
+    }
     compileSdkVersion 29
     defaultConfig {
         applicationId "org.piwigo.android"
@@ -52,6 +56,7 @@ android {
         versionCode 102
         versionName "1.0.2"
         multiDexEnabled true
+        signingConfig signingConfigs.debug
     }
     buildTypes {
         debug {
@@ -148,4 +153,5 @@ dependencies {
     testImplementation 'androidx.appcompat:appcompat:1.1.0'
     testAnnotationProcessor 'com.google.guava:guava:24.1-jre'
     testImplementation 'com.google.code.findbugs:jsr305:3.0.2'
+    compile 'com.jakewharton.picasso:picasso2-okhttp3-downloader:1.1.0'
 }

--- a/app/src/main/java/org/piwigo/internal/di/module/ApplicationModule.java
+++ b/app/src/main/java/org/piwigo/internal/di/module/ApplicationModule.java
@@ -28,7 +28,7 @@ import org.piwigo.PiwigoApplication;
 import org.piwigo.accounts.UserManager;
 import org.piwigo.internal.cache.PiwigoImageCache;
 import org.piwigo.io.repository.PreferencesRepository;
-
+import com.jakewharton.picasso.OkHttp3Downloader;
 import javax.inject.Singleton;
 
 import dagger.Module;
@@ -51,6 +51,7 @@ public class ApplicationModule {
         return new Picasso.Builder(application)
                 .indicatorsEnabled(BuildConfig.DEBUG) //We may not want this for production build..
                 .memoryCache(new PiwigoImageCache(application)) //What about this ?
+                .downloader(new OkHttp3Downloader(application))
                 .build();
     }
 


### PR DESCRIPTION
There is a problem downloading images from Piwigo when the the server is sat behind a reverse proxy that terminates the https client connection, and requests images from Piwigo.  The Piwigo server url base is https, but all image urls coming from the backend are http.  

Most reverse proxies will redirect a request for the http image on the internet to a https request before hitting the backend.  This patch changes the Picasso component to make use of a okhttp3 download agent per an implementation from Jake Wharton https://github.com/JakeWharton/picasso2-okhttp3-downloader/blob/master/LICENSE.txt

The change is actually just 3 lines on top of v1.0.2 release tag. but includes other changes to files from Android Studio.

There are no logic changes in Piwigo to support this, its a straight drop in of a different download engine to the Picasso framework, but this download engine supports graceful 302 & 301 redirects to the  https URL returned from the proxy, without needing to handle it in the piwigo code.



