### PR TITLE
fix #264

### DIFF
--- a/app/src/main/java/org/piwigo/ui/main/MainActivity.java
+++ b/app/src/main/java/org/piwigo/ui/main/MainActivity.java
@@ -277,6 +277,7 @@ public class MainActivity extends BaseActivity implements HasAndroidInjector {
     protected void onResume() {
         super.onResume();
         MainViewModel viewModel = new ViewModelProvider(this, viewModelFactory).get(MainViewModel.class);
+        viewModel.showingRootAlbum.addOnPropertyChangedCallback(mDrawerCallBack);
         speedDialView.setVisibility(viewModel.displayFab.get() ? View.VISIBLE : View.INVISIBLE);
         EventBus.getDefault().register(this);
     }

--- a/app/src/main/java/org/piwigo/ui/main/MainActivity.java
+++ b/app/src/main/java/org/piwigo/ui/main/MainActivity.java
@@ -156,7 +156,6 @@ public class MainActivity extends BaseActivity implements HasAndroidInjector {
                 mDrawerToggle.setDrawerIndicatorEnabled(((ObservableBoolean) sender).get());
             }
         };
-        viewModel.showingRootAlbum.addOnPropertyChangedCallback(mDrawerCallBack);
 
         snackProgressBarManager = new SnackProgressBarManager(findViewById(android.R.id.content), null);
 


### PR DESCRIPTION
I guess this would fix the issue, as we have removed the PropertyChangedCallback(mDrawerCallBack) in MainActivity.onPause() but registered it in onCreate() instead of onResume()...